### PR TITLE
fix(database): change `size` column type to BIGINT UNSIGNED

### DIFF
--- a/packages/server/src/modules/file/file.entity.ts
+++ b/packages/server/src/modules/file/file.entity.ts
@@ -32,6 +32,8 @@ export class File {
 
   /** 文件大小(字节) */
   @Column({
+    type: 'bigint',
+    unsigned: true,
     nullable: true,
   })
   size: number;


### PR DESCRIPTION
## Fixes
Previously, the `size` column in `file` table was defined as INT, which caused "Out of range value" errors when storing large file sizes (e.g. 2778936252).

- Modified column type from INT to BIGINT UNSIGNED via ALTER TABLE
- Updated corresponding TypeORM entity definition
- Ensures support for file sizes up to 18,446,744,073,709,551,615
